### PR TITLE
chore(ci): GHA - build container image on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,25 @@ jobs:
           java-version: 11
           distribution: 'zulu'
           cache: 'gradle'
+      - name: Extract repository name
+        id: extract_repo_name
+        run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
       - name: Build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build --stacktrace ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist"
+      - name: Build slim container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.slim
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-slim"
+      - name: Build ubuntu container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.ubuntu
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:spinnaker-${{ env.GITHUB_REF_NAME }}-latest-unvalidated-ubuntu"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on: [ pull_request ]
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:
   build:
@@ -15,5 +16,25 @@ jobs:
         java-version: 11
         distribution: 'zulu'
         cache: 'gradle'
+    - name: Extract repository name
+      id: extract_repo_name
+      run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
     - name: Build
-      run: ./gradlew build
+      run: "./gradlew build ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist"
+    - name: Build slim container image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile.slim
+        tags: |
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-slim"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-slim"
+    - name: Build ubuntu container image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile.ubuntu
+        tags: |
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:latest-ubuntu"
+          "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ github.sha }}-ubuntu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:
   release:
@@ -30,6 +31,9 @@ jobs:
           echo ::set-output name=SKIP_RELEASE::${SKIP_RELEASE}
           echo ::set-output name=IS_CANDIDATE::${IS_CANDIDATE}
           echo ::set-output name=RELEASE_VERSION::${RELEASE_VERSION}
+      - name: Extract repository name
+        id: extract_repo_name
+        run: echo ::set-output name=REPO::${GITHUB_REPOSITORY##*/}
       - name: Release build
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.release_info.outputs.RELEASE_VERSION }}
@@ -39,7 +43,30 @@ jobs:
           ORG_GRADLE_PROJECT_nexusPgpSigningKey: ${{ secrets.NEXUS_PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_nexusPgpSigningPassword: ${{ secrets.NEXUS_PGP_SIGNING_PASSWORD }}
         run: |
-          ./gradlew --info publishToNexus closeAndReleaseNexusStagingRepository
+          ./gradlew --info ${{ steps.extract_repo_name.outputs.REPO }}-web:installDist publishToNexus closeAndReleaseNexusStagingRepository
+      - name: Login to GAR
+        uses: docker/login-action@v1
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+      - name: Build slim container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.slim
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-slim"
+      - name: Build ubuntu container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.ubuntu
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.extract_repo_name.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-ubuntu"
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1


### PR DESCRIPTION
shared:
- GHA doesn't have a repository name env var, eg: spinnaker/"clouddriver" so
  add a step to extract the name
- Change build step to create installation distribution for use in
  following container image build steps. This also runs unit tests
- add Alpine/slim container build step
- add Ubuntu container build step

on PR:
- build only and don't push
- validates unit tests pass and Dockerfile's build

on Merge to specific branches:
- build and push with branch tags:
  - `master` -> `spinnaker-master-latest-unvalidated-{slim|ubuntu}`
  - `version-*` ->
  `spinnaker-{version-*}-latest-unvalidated-{slim-ubuntu}`
- TODO: change `version-*` to `release-*` to build on merge to release
  branches?

on Release (push of tag x.y.z):
- build and push with version tag.
- TODO: clarify if this is still necessary or should be revised to be
  inline with `release-x.y.z`

TODO: confirm if we need/want {date} in image tag name per previous CI.
